### PR TITLE
updated logic to avoid race condition between poll and startTime/clos…

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -10,6 +10,7 @@
     "closeTime": 17,
     "polling": true,
     "pollInterval": 60,
+    "movementPollInterval": 2,
     "username": "garage",
     "password": "********",
     "manufacturer": "BFT",

--- a/config.schema.json
+++ b/config.schema.json
@@ -10,26 +10,27 @@
                 "type": "string",
                 "required": true,
                 "description": "Name to appear in the Home app"
-
             },
             "http_method": {
                 "title": "HTTP Method",
                 "type": "string",
-                "oneOf": [{
-                    "title": "GET",
-                    "enum": [
-                        "GET"
-                    ]
-                }, {
-                    "title": "POST",
-                    "enum": [
-                        "POST"
-                    ]
-                }],
+                "oneOf": [
+                    {
+                        "title": "GET",
+                        "enum": [
+                            "GET"
+                        ]
+                    },
+                    {
+                        "title": "POST",
+                        "enum": [
+                            "POST"
+                        ]
+                    }
+                ],
                 "required": true,
                 "default": "GET",
                 "description": "The HTTP method to be used to communicate with the device API."
-
             },
             "openURL": {
                 "title": "Open URL",
@@ -53,7 +54,6 @@
                 "type": "string",
                 "description": "Password if HTTP authentication is enabled"
             },
-
             "openTime": {
                 "title": "Time to open the door",
                 "type": "integer",
@@ -91,6 +91,12 @@
                 "default": 120,
                 "description": "Time (in seconds) between device polls (if `polling` is enabled) "
             },
+            "movementPollInterval": {
+                "title": "Movement Polling interval",
+                "type": "integer",
+                "default": 2,
+                "description": "Time (in seconds) between device polls when moving (if `polling` is enabled) "
+            },
             "statusURL": {
                 "title": "Status polling URL",
                 "type": "string",
@@ -126,7 +132,6 @@
                 "default": "3",
                 "description": "Regex that will match the `closing` state of the relay status (e.g. `closing`)"
             },
-
             "manufacturer": {
                 "title": "Manufactor",
                 "type": "string",
@@ -143,7 +148,6 @@
                 "default": false,
                 "description": "Turn on debug mode, i.e. additional information will show up on the homebridge log."
             }
-
         }
     }
 }


### PR DESCRIPTION
### Description
This PR significantly improves the polling logic to handle garage door transitions (opening/closing) more intelligently.

### Problem
1. **Race Conditions**: Previously, the plugin would continue to poll the status URL at the normal interval even while the door was moving. This could lead to false positives (e.g., detecting "closed" momentarily while opening) or inconsistent state reports.
2. **Fixed Timing**: The plugin relied solely on `openTime` and `closeTime` to determine when the operation finished.
    - If the door opened faster than the configured time, HomeKit would lag and show "Opening..." incorrectly.
    - There is an issue (since my door has the sensor on "open") that it will immediately report as closed

### Solution
This update refactors the polling mechanism to separate "Status Fetching" from "State Updating" and adds a dedicated polling strategy for movement:

- **Movement Awareness**: Introduced an internal `isMoving` state. The standard `pollInterval` is paused while the door is in motion to prevent conflicting updates.
- **Active Movement Polling**: During `simulateOpen` and `simulateClose`, the plugin now polls the device at a faster rate (configured via `movementPollInterval`, default 2s).
- **Early Detection**: If the device reports the target state (e.g., "Open") *before* the `openTime` concludes, the plugin immediately updates HomeKit to "Open" and stops the timer.
- **Reliable Fallback**: If the operation times out (e.g., the door got stuck), the plugin performs a final poll to update HomeKit with the *actual* device state, rather than assuming success.

### Configuration
- Added `movementPollInterval`: Time (in seconds) between device polls when moving (default: `2`).

### Changes
- Refactored `index.js` to implement `_fetchStatus` and separate movement logic.
- Updated `config.schema.json` and `config.sample.json` with the new option.
- Updated `README.md` to document the new behavior.

### Verification
- Verified that standard polling pauses during movement.
- Verified that the door state updates immediately if the device reports "Open"/"Closed" early.
- Verified that the correct actual state is reported if the operation times out.